### PR TITLE
Support "P" (road+tree symbol, often used in "Think before you print"…

### DIFF
--- a/chrome/content/options.xul
+++ b/chrome/content/options.xul
@@ -21,6 +21,7 @@
 			<preference id="smiley-fixer-square" name="extensions.smileyfixer.square" type="string"/>
 			<preference id="smiley-fixer-toplightarrow" name="extensions.smileyfixer.toplightarrow" type="string"/>
 			<preference id="smiley-fixer-leftright" name="extensions.smileyfixer.leftright" type="string"/>
+			<preference id="smiley-fixer-tree" name="extensions.smileyfixer.tree" type="string"/>
 		</preferences>
 
 		<groupbox>
@@ -40,6 +41,7 @@
 						<label flex="1" value="&squareText;" class="pref-label"/>
 						<label flex="1" value="&toplightarrowText;" class="pref-label"/>
 						<label flex="1" value="&leftrightText;" class="pref-label"/>
+						<label flex="1" value="&treeText;" class="pref-label"/>
 					</vbox>
 					<vbox>
 						<textbox flex="1" id="unsmiley" preference="smiley-fixer-unsmiley"/>
@@ -54,6 +56,7 @@
 						<textbox flex="1" id="square" preference="smiley-fixer-square"/>
 						<textbox flex="1" id="toplightarrow" preference="smiley-fixer-toplightarrow"/>
 						<textbox flex="1" id="leftright" preference="smiley-fixer-leftright"/>
+						<textbox flex="1" id="tree" preference="smiley-fixer-tree"/>
 					</vbox>
 				</hbox>
 

--- a/chrome/content/smileyfixer.js
+++ b/chrome/content/smileyfixer.js
@@ -68,7 +68,8 @@ if (typeof SmileyFixer == "undefined") {
             '·': 'blob',
             'n': 'square',
             'ó': 'leftright',
-            'Ø': 'toplightarrow'
+            'Ø': 'toplightarrow',
+            'P': 'tree'
         };
         for (var key in mapping) {
             mapping[key] = SmileyFixer.getUnicodePref(mapping[key]);
@@ -79,6 +80,7 @@ if (typeof SmileyFixer == "undefined") {
             try {
                 var span = spans[i];
                 if (span.style.fontFamily === "Wingdings" ||
+		    span.style.fontFamily === "Webdings" ||
                     span.style.fontFamily === "Symbol") {
                     SmileyFixer.fixSpan(span, mapping);
                 }
@@ -92,6 +94,7 @@ if (typeof SmileyFixer == "undefined") {
                 var font = fonts[i];
                 var face = font.getAttribute('face');
                 if (face === "Wingdings" ||
+		    face === "Webdings" ||
                     face === "Symbol") {
                     SmileyFixer.fixSpan(font, mapping);
                 }

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -8,6 +8,7 @@ pref("extensions.smileyfixer.longarrow", "→");
 pref("extensions.smileyfixer.leftright", "⬄");
 pref("extensions.smileyfixer.blob", "•");
 pref("extensions.smileyfixer.bomba", "●~*");
+pref("extensions.smileyfixer.tree", "-");
 pref("extensions.smileyfixer.square", "■");
 pref("extensions.smileyfixer.toplightarrow", "➢");
 pref("extensions.smileyfixer.debug", false);

--- a/locale/en-US/options.dtd
+++ b/locale/en-US/options.dtd
@@ -11,6 +11,7 @@
 <!ENTITY squareText "Square Bullet">
 <!ENTITY toplightarrowText "Top-lit right arrow">
 <!ENTITY leftrightText "Left-right arrow">
+<!ENTITY treeText "Tree">
 <!ENTITY skullText "Skull">
 <!ENTITY fixingsEnabled "Fixings Enabled">
 <!ENTITY debugEnabled "Debug mode (altered text has a red background)">


### PR DESCRIPTION
I often get emails with a little tree symbol just before the "Think before you print" crap. I wished I had an extension to simply "zap" region of texts based on regular expressions, but this will do. It replaces the "P" with "-", since I saw two palm/xmas tree symbols in unicode, but no font I have has the actual glyph.