### PR TITLE
Also reset font size when substituting characters.

### DIFF
--- a/chrome/content/smileyfixer.js
+++ b/chrome/content/smileyfixer.js
@@ -30,7 +30,8 @@ if (typeof SmileyFixer == "undefined") {
             return;
         }
         span.firstChild.data = result;
-        origSpan.style.fontFamily = "";
+        origSpan.style.fontFamily = "inherit";
+        origSpan.style.fontSize = "inherit";
         /* show in red if debugging */
         if (SmileyFixer.prefs.getBoolPref("debug"))
             origSpan.style.backgroundColor = "#ff0000";


### PR DESCRIPTION
Also reset fontSize, since it's often used to "adjust" the symbol position over the regular text.